### PR TITLE
fix console errors for waiting clock icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homestars-icons",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homestars-icons",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "HomeStars componentized icons",
   "main": "dist/index.js",
   "repository": {

--- a/src/homestars-icons/icons/WaitingClock.js
+++ b/src/homestars-icons/icons/WaitingClock.js
@@ -27,7 +27,7 @@ function WaitingClock({ fill, stroke, strokeWidth }) {
         stroke={stroke}
         strokeWidth={strokeWidth}
         fill={fill}
-        fill-rule="evenodd"
+        fillRule="evenodd"
       >
         <g
           id="Company/Chat-view----empty-state"
@@ -53,8 +53,8 @@ function WaitingClock({ fill, stroke, strokeWidth }) {
               y2="11"
               id="Stroke-3"
               stroke="#535455"
-              stroke-linecap="round"
-              stroke-linejoin="round"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             ></line>
             <line
               x1="10"
@@ -63,8 +63,8 @@ function WaitingClock({ fill, stroke, strokeWidth }) {
               y2="11"
               id="Stroke-3"
               stroke="#E07474"
-              stroke-linecap="round"
-              stroke-linejoin="round"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             ></line>
           </g>
         </g>


### PR DESCRIPTION
some console errors found when testing Homeowner Inbox. It didn't affect the actual rendering of the icon, but fix to clean out errors. 